### PR TITLE
Implement loss condition

### DIFF
--- a/Angled/Assets/EnemyMovement.cs
+++ b/Angled/Assets/EnemyMovement.cs
@@ -7,12 +7,12 @@ public class EnemyMovement : MonoBehaviour
     private float moveSpeed = 2.5f;
     void OnCollisionEnter2D(Collision2D collision)
     {
-        if (collision.gameObject.tag == "Player")
+        GameObject playerObject = GameObject.Find("Player");
+        if (collision.gameObject == playerObject)
         {
-            if(GameObject.Find("Player").GetComponent<PlayerController>().lives > 0)
-                GameObject.Find("Player").GetComponent<PlayerController>().lives--;
+            PlayerController playerController = playerObject.GetComponent<PlayerController>();
+            playerController.reduceLife();
         }
-
     }
 
     // Update is called once per frame

--- a/Angled/Assets/Scenes/TestScene1.unity
+++ b/Angled/Assets/Scenes/TestScene1.unity
@@ -434,6 +434,7 @@ RectTransform:
   - {fileID: 762972452}
   - {fileID: 1807083144}
   - {fileID: 457255463}
+  - {fileID: 1760644526}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -784,6 +785,96 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &1760644525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1760644526}
+  - component: {fileID: 1760644529}
+  - component: {fileID: 1760644528}
+  - component: {fileID: 1760644527}
+  m_Layer: 5
+  m_Name: LivesCounter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1760644526
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1760644525}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.4448851, y: 0.44442257, z: 0.96666}
+  m_Children: []
+  m_Father: {fileID: 785121012}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -538, y: -300}
+  m_SizeDelta: {x: 160, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1760644527
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1760644525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b24638141724d9d4cb0f7d420c3b9249, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1760644528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1760644525}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 100
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
+    m_LineSpacing: 1
+  m_Text: 'Lives:'
+--- !u!222 &1760644529
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1760644525}
+  m_CullTransparentMesh: 0
 --- !u!1 &1807083143
 GameObject:
   m_ObjectHideFlags: 0
@@ -1120,8 +1211,7 @@ PrefabInstance:
       propertyPath: m_Name
       value: Enemy
       objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: -4306546533418657318, guid: a3f3366ec0742f94fa772346bc4f69fb, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a3f3366ec0742f94fa772346bc4f69fb, type: 3}
 --- !u!1001 &7650974852438766950
 PrefabInstance:
@@ -1135,9 +1225,24 @@ PrefabInstance:
       propertyPath: cam
       value: 
       objectReference: {fileID: 1289730846}
+    - target: {fileID: 7650974851136024322, guid: 7dbc6fd88ae939246a2e318230042405,
+        type: 3}
+      propertyPath: lives
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650974851136024322, guid: 7dbc6fd88ae939246a2e318230042405,
+        type: 3}
+      propertyPath: startingLives
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 7650974851136024324, guid: 7dbc6fd88ae939246a2e318230042405,
         type: 3}
       propertyPath: m_Name
+      value: Player
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650974851136024324, guid: 7dbc6fd88ae939246a2e318230042405,
+        type: 3}
+      propertyPath: m_TagString
       value: Player
       objectReference: {fileID: 0}
     - target: {fileID: 7650974851136024325, guid: 7dbc6fd88ae939246a2e318230042405,

--- a/Angled/Assets/Scripts/GameOver.cs
+++ b/Angled/Assets/Scripts/GameOver.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GameOver
+{
+    public static void Run()
+    {
+        Debug.Log("Game over!");
+        // TODO: Add a 'Game Over' scene instead of terminating the applicaiton
+        UnityEditor.EditorApplication.isPlaying = false; // Needed to end the game if running in-editor
+        Application.Quit();
+    }
+}

--- a/Angled/Assets/Scripts/GameOver.cs.meta
+++ b/Angled/Assets/Scripts/GameOver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a7a721f59859be41815da7d24b52ac8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Angled/Assets/Scripts/LivesScript.cs
+++ b/Angled/Assets/Scripts/LivesScript.cs
@@ -17,6 +17,7 @@ public class LivesScript : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        lives.text = "Lives: " + GameObject.Find("Player").GetComponent<PlayerController>().lives.ToString();
+        PlayerController playerContoller = GameObject.Find("Player").GetComponent<PlayerController>();
+        lives.text = "Lives: " + playerContoller.GetLives().ToString();
     }
 }

--- a/Angled/Assets/Scripts/PlayerController.cs
+++ b/Angled/Assets/Scripts/PlayerController.cs
@@ -1,12 +1,13 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
 public class PlayerController : MonoBehaviour
 {
+    [field: SerializeField] private int startingLives;
     // General
     public Rigidbody2D rb;
-    public int lives;
+    private int lives;
 
     // Movement
     //public float moveSpeed = 5f;
@@ -20,7 +21,7 @@ public class PlayerController : MonoBehaviour
 
     void Start()
     {
-        lives = 3;
+        lives = startingLives;
         walkSpeed = 5.0f;
     }
 

--- a/Angled/Assets/Scripts/PlayerController.cs
+++ b/Angled/Assets/Scripts/PlayerController.cs
@@ -49,4 +49,9 @@ public class PlayerController : MonoBehaviour
         float angle = Mathf.Atan2(lookDir.y, lookDir.x) * Mathf.Rad2Deg - 90;
         rb.rotation = angle;
     }
+
+    public int GetLives()
+    {
+        return lives;
+    }
 }

--- a/Angled/Assets/Scripts/PlayerController.cs
+++ b/Angled/Assets/Scripts/PlayerController.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -32,7 +32,6 @@ public class PlayerController : MonoBehaviour
         //movement.x = Input.GetAxis("Horizontal");
         //movement.y = Input.GetAxis("Vertical");
         mousePos = cam.ScreenToWorldPoint(Input.mousePosition);
-        if (lives <= 0) Application.Quit();
     }
 
     // Fixed Update (called 50 times a second)
@@ -43,11 +42,20 @@ public class PlayerController : MonoBehaviour
         maxSpeed = curSpeed;
         rb.velocity = new Vector2(Mathf.Lerp(0, Input.GetAxis("Horizontal") * curSpeed, 0.8f), Mathf.Lerp(0, Input.GetAxis("Vertical") * curSpeed, 0.8f));
         //rb.MovePosition(rb.position + movement * moveSpeed * Time.fixedDeltaTime);
-        
+
         // Aiming
         Vector2 lookDir = mousePos - rb.position;
         float angle = Mathf.Atan2(lookDir.y, lookDir.x) * Mathf.Rad2Deg - 90;
         rb.rotation = angle;
+    }
+
+    public void reduceLife()
+    {
+        lives--;
+        if (lives <= 0)
+        {
+            GameOver.Run();
+        }
     }
 
     public int GetLives()


### PR DESCRIPTION
Changes:
- The player's life variable is now displayed on-screen
- Tweaked how the player's lives are exposed in-editor:
    - Made PlayerController.lives private to prevent the ability to edit it mid-game
    - Added a new PlayerController.startingLives member that is visible in-editor, Player.Controller.lives is initialized with this value
- The code that checked player-enemy collisions wasn't getting triggered since the Player object wasn't assigned a tag
    - Added the missing tag for Player
    - Changed the collision detection to avoid relying on tags, it now just checks if the other collision object *is* the player object
- Added a script to end the game if the player's lives hits 0, this should probably be improved in the future to transition to a 'Game Over' screen instead